### PR TITLE
Add git submodules to build instructions

### DIFF
--- a/docs/development/build.md
+++ b/docs/development/build.md
@@ -35,6 +35,15 @@ The rest of this page assumes that you checked out the sources using one of the 
 
 This document assumes that you work with `master` branch or with your own branch forked from `master`
 
+## Submodules
+
+This repository has some submodules that we need to pull:
+
+```
+    cd /tmp/ganttproject/
+    git submodule update --init
+```
+
 ## Building with Gradle
 
 If everything is OK with your environment then the following will build


### PR DESCRIPTION
I had a problem building, which was solved by this:

https://help.ganttproject.biz/t/could-not-determine-the-dependencies-of-task-distbin/1643

It seems like this should be in the build instructions. I didn't put it in the `git clone` section because it should go after the section about choosing a branch.